### PR TITLE
Expose the constructor so that a custom HttpClient can be passed in.

### DIFF
--- a/dotAPNS/ApnsClient.cs
+++ b/dotAPNS/ApnsClient.cs
@@ -45,7 +45,7 @@ namespace dotAPNS
         readonly string _bundleId;
         bool _useSandbox;
 
-        ApnsClient(HttpClient http, [NotNull] X509Certificate cert)
+        public ApnsClient(HttpClient http, [NotNull] X509Certificate cert)
         {
             _http = http;
             var split = cert.Subject.Split(new[] { "0.9.2342.19200300.100.1.1=" }, StringSplitOptions.RemoveEmptyEntries);


### PR DESCRIPTION
This is important for using this project with the .NET Framework instead of .NET Core, where a custom WinHttpHandler can to be passed in to use HTTP/2.