### PR TITLE
Added `cert.Subject → uid` as topic source

### DIFF
--- a/dotAPNS/ApnsClient.cs
+++ b/dotAPNS/ApnsClient.cs
@@ -62,9 +62,16 @@ namespace dotAPNS
             {
                 // On Linux .NET Core cert.Subject prints `userId=xxx` instead of `0.9.2342.19200300.100.1.1=xxx`
                 split = cert.Subject.Split(new[] { "userId=" }, StringSplitOptions.RemoveEmptyEntries);
-                if (split.Length != 2)
-                    throw new InvalidOperationException("Provided certificate does not appear to be a valid APNs certificate.");
             }
+            if (split.Length != 2)
+            {
+                // if subject prints `uid=xxx` instead of `0.9.2342.19200300.100.1.1=xxx`
+                split = cert.Subject.Split(new[] { "uid=" }, StringSplitOptions.RemoveEmptyEntries);
+            }
+
+            if (split.Length != 2)
+                throw new InvalidOperationException("Provided certificate does not appear to be a valid APNs certificate.");
+
             string topic = split[1];
             _isVoipCert = topic.EndsWith(".voip");
             _bundleId = split[1].Replace(".voip", "");


### PR DESCRIPTION
When I load our push cert (which worked with `Redth/PushSharp`), the bundleId is in the subject filed `uid`, which isn't parsed by `ApnsClient(HttpClient http, [NotNull] X509Certificate cert)` when using `public static ApnsClient CreateUsingCustomHttpClient([NotNull] HttpClient httpClient, [NotNull] X509Certificate2 cert)`

![applePushCert](https://user-images.githubusercontent.com/13467300/90612725-bb681e00-e208-11ea-80c2-25899ffdf2d0.png)
