### PR TITLE
Improved error handling (when a http status code > 400 was recieved)

### DIFF
--- a/dotAPNS/ApnsResponseReason.cs
+++ b/dotAPNS/ApnsResponseReason.cs
@@ -4,6 +4,7 @@
     {
         Success,
         Unknown,
-        DeviceTokenNotForTopic
+        DeviceTokenNotForTopic,
+        MissingProviderToken,
     }
 }


### PR DESCRIPTION
Currently it always shows `Successful` on every status code != 400