### PR TITLE
expose unregistered-timestamp in ApnsResponse

### DIFF
--- a/dotAPNS/ApnsClient.cs
+++ b/dotAPNS/ApnsClient.cs
@@ -174,7 +174,7 @@ namespace dotAPNS
             }
 
             Debug.Assert(errorPayload != null);
-            return ApnsResponse.Error(errorPayload.Reason, errorPayload.ReasonRaw);
+            return ApnsResponse.Error(errorPayload.Reason, errorPayload.ReasonRaw, errorPayload.Timestamp);
         }
 
         public static ApnsClient CreateUsingJwt([NotNull] HttpClient http, [NotNull] ApnsJwtOptions options)

--- a/dotAPNS/ApnsResponse.cs
+++ b/dotAPNS/ApnsResponse.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
 
 namespace dotAPNS
 {
@@ -7,17 +8,19 @@ namespace dotAPNS
         public ApnsResponseReason Reason { get; }
         public string ReasonString { get; }
         public bool IsSuccessful { get; }
+        public DateTimeOffset? Timestamp {get; }
 
         [JsonConstructor]
-        ApnsResponse(ApnsResponseReason reason, string reasonString, bool isSuccessful)
+        ApnsResponse(ApnsResponseReason reason, string reasonString, bool isSuccessful, DateTimeOffset? timestamp)
         {
             Reason = reason;
             ReasonString = reasonString;
             IsSuccessful = isSuccessful;
+            Timestamp = timestamp;
         }
 
-        public static ApnsResponse Successful() => new ApnsResponse(ApnsResponseReason.Success, null, true);
+        public static ApnsResponse Successful() => new ApnsResponse(ApnsResponseReason.Success, null, true, null);
 
-        public static ApnsResponse Error(ApnsResponseReason reason, string reasonString) => new ApnsResponse(reason, reasonString, false);
+        public static ApnsResponse Error(ApnsResponseReason reason, string reasonString, DateTimeOffset? timestamp=null) => new ApnsResponse(reason, reasonString, false, timestamp);
     }
 }


### PR DESCRIPTION
another small change: dotAPNS reads the "unregistered" timestamp, but does not expose it to the application. This change fixes that.