### PR TITLE
Add support for iOS 15 location pushes

### DIFF
--- a/dotAPNS/ApnsClient.cs
+++ b/dotAPNS/ApnsClient.cs
@@ -304,6 +304,8 @@ namespace dotAPNS
                     break;
                 case ApplePushType.Voip:
                     return _bundleId + ".voip";
+                case ApplePushType.Location:
+                    return _bundleId + ".location-query";
                 case ApplePushType.Unknown:
                 default:
                     throw new ArgumentOutOfRangeException(nameof(pushType), pushType, null);

--- a/dotAPNS/ApplePushType.cs
+++ b/dotAPNS/ApplePushType.cs
@@ -5,6 +5,7 @@
         Unknown,
         Alert,
         Background,
-        Voip
+        Voip,
+        Location
     }
 }


### PR DESCRIPTION
In iOS 15 Apple introduced a new type of pushes (location pushes).

More info: https://developer.apple.com/documentation/corelocation/cllocationmanager/creating_a_location_push_service_extension