### PR TITLE
Add support for Live Activities

### DIFF
--- a/dotAPNS/ApnsClient.cs
+++ b/dotAPNS/ApnsClient.cs
@@ -307,6 +307,8 @@ namespace dotAPNS
                     return _bundleId + ".voip";
                 case ApplePushType.Location:
                     return _bundleId + ".location-query";
+                case ApplePushType.LiveActivity:
+                    return _bundleId + ".push-type.liveactivity";
                 case ApplePushType.Unknown:
                 default:
                     throw new ArgumentOutOfRangeException(nameof(pushType), pushType, null);

--- a/dotAPNS/ApplePushType.cs
+++ b/dotAPNS/ApplePushType.cs
@@ -6,6 +6,7 @@
         Alert,
         Background,
         Voip,
-        Location
+        Location,
+        LiveActivity
     }
 }


### PR DESCRIPTION
In iOS 16.1 Apple added support for Live Activities. This PR adds `.liveActivity` to the `ApplePushType` enum and `apns-topic` to the client.

More info:
https://developer.apple.com/documentation/activitykit/updating-live-activities-with-activitykit-push-notifications