### PR TITLE
Minor perf improvements and allow to get certificate information externally

### DIFF
--- a/dotAPNS/dotAPNS.csproj
+++ b/dotAPNS/dotAPNS.csproj
@@ -4,10 +4,11 @@
     <TargetFrameworks>net46;netstandard2.0;netstandard2.1</TargetFrameworks>
     <Authors>alexalok</Authors>
     <Description>dotAPNS is a library used to send push notifications to Apple devices using Apple Push Notification service.</Description>
-    <Version>4.4.1</Version>
+    <Version>4.5.0</Version>
     <Copyright>© alexalok 2019-2024</Copyright>
     <PackageReleaseNotes>
-		* Unpinned System.Net.Http.WinHttpHandler version
+		* Minor perf improvements (#131)
+        * Allow getting APNs certificate information externally (#131)
 	</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/alexalok/dotAPNS</PackageProjectUrl>
     <RepositoryUrl>https://github.com/alexalok/dotAPNS</RepositoryUrl>


### PR DESCRIPTION
Hey @alexalok 

Would you be open to a small PR?

It improves performance when creating the ApnsClient from a certificate and allows external usage of GetCertificateInfo.

Performance changes:
- Don't allocate the array used for splitting (single reused instance)
- Avoid re-splitting
- Avoid operations when non VoIP, and use substring instead of Replace